### PR TITLE
Update lzma-native dependency to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "del": "2.1.0",
     "gunzip-maybe": "1.2.1",
     "lodash": "3.10.1",
-    "lzma-native": "0.5.0",
+    "lzma-native": "1.0.3",
     "mkdirp": "0.5.1",
     "plist": "1.2.0",
     "ps-node": "0.0.5",


### PR DESCRIPTION
This updates the lzma-native dependency to 1.0.3.
The most important update in v1.x.x is the support for [node-pre-gyp](https://github.com/mapbox/node-pre-gyp), which should speed up builds significantly and, in many cases, removes the necessity for a compiler toolchain.

See also addaleax/lzma-native#12, gamejolt/issue-tracker#493.

And btw, I can’t really say anything about the other dependencies, but `npm outdated` returns a few more candidates for updating.